### PR TITLE
Replace player sprite with 3D truck mesh

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,7 @@
 {
   "imports": {
     "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
     "lil-gui": "https://cdn.jsdelivr.net/npm/lil-gui@0.19/dist/lil-gui.esm.js"
   }
 }

--- a/lib/car/playerMesh.js
+++ b/lib/car/playerMesh.js
@@ -1,0 +1,151 @@
+/**
+ * lib/car/playerMesh.js — 3D player truck.
+ *
+ * Drop-in replacement for `playerSprite.js`. Loads a GLB once and poses it
+ * each frame from the existing Vehicle state (position, yaw, speed,
+ * steerInput). Vehicle physics + collision are untouched — issues #2 and #3
+ * meet at this seam: this module owns rendering only.
+ *
+ * Body roll on steer + slight pitch on accel are ported from
+ * crazy-cabbie/src/vehicle.js so the truck reads as planted on the road.
+ *
+ * Usage:
+ *   const pm = await createPlayerMesh(scene);
+ *   pm.update(vehicle, dt);   // every frame, before render
+ *   pm.destroy();             // on city rebuild / cleanup
+ */
+
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { CAR } from '../config.js';
+
+const TRUCK_URL    = './data/vehicles/player-truck.glb';
+const TRUCK_SCALE  = 8;       // tuned by eye against the city.
+const FORWARD_OFFSET_Y = 0;   // adjust if the model floats/sinks.
+// Authored facing direction. The user's truck model is authored facing -Z
+// already (matches valkyrie's vehicle.forward), so no offset is needed.
+const MODEL_FACING_OFFSET = 0;
+
+// Body lean / pitch tuning — kept gentle. Lerp factors are per-second.
+const ROLL_AMPLITUDE  = 0.10;     // radians at full steer & speed
+const ROLL_LERP_RATE  = 9;
+const PITCH_AMPLITUDE = 0.045;
+const PITCH_LERP_RATE = 6;
+
+const STEER_THRESHOLD = 0.05;  // below this, hold neutral roll
+
+// Reused module-cached loader so repeated city rebuilds don't re-parse the GLB.
+let _cachedScene = null;
+async function loadTruckScene() {
+  if (_cachedScene) return _cachedScene;
+  const loader = new GLTFLoader();
+  const gltf = await loader.loadAsync(TRUCK_URL);
+  _cachedScene = gltf.scene;
+  // Mark every mesh so _clearCityMeshes() doesn't dispose shared resources.
+  _cachedScene.traverse((n) => {
+    if (n.isMesh) {
+      n.userData.sharedAsset = true;
+      n.castShadow = true;
+      n.receiveShadow = false;
+    }
+  });
+  return _cachedScene;
+}
+
+/**
+ * @param {import('three').Scene} scene
+ */
+export async function createPlayerMesh(scene) {
+  const src = await loadTruckScene();
+
+  // One clone per active player mesh — materials are shared across clones.
+  const truck = src.clone(true);
+  truck.traverse((n) => { if (n.isMesh) n.userData.sharedAsset = true; });
+
+  // The "body" group is what we lean / pitch — separate from the outer
+  // group so heading rotation around Y is unaffected.
+  const body = new THREE.Group();
+  body.add(truck);
+  truck.scale.setScalar(TRUCK_SCALE);
+  truck.rotation.y = MODEL_FACING_OFFSET;
+
+  // Outer group holds world position + heading.
+  const root = new THREE.Group();
+  root.add(body);
+  root.userData.isPlayerSprite = true;  // _clearCityMeshes() exclusion flag
+  scene.add(root);
+
+  // Detect Kenney-style named wheel nodes. Optional — the user's custom
+  // truck likely doesn't have them, in which case `wheels` stays empty
+  // and the wheel-spin step is skipped silently.
+  const wheels = [];
+  truck.traverse((n) => {
+    if (n.name && /^wheel[-_]/i.test(n.name)) {
+      wheels.push({ node: n, isFront: /front/i.test(n.name) });
+    }
+  });
+  // Wheel radius — guessed; only matters if we found wheels.
+  const wheelRadius = 0.35 * TRUCK_SCALE;
+
+  let _roll = 0;
+  let _pitch = 0;
+  let _lastSpeed = 0;
+
+  /**
+   * @param {{ position: THREE.Vector3, yaw: number, speed: number, steerInput: number }} vehicle
+   * @param {number} dt
+   */
+  function update(vehicle, dt = 1 / 60) {
+    // Position + heading (Y rotation matches vehicle.yaw — same convention
+    // valkyrie uses everywhere else, see vehicle.setPositionYaw).
+    root.position.set(
+      vehicle.position.x,
+      vehicle.position.y + FORWARD_OFFSET_Y,
+      vehicle.position.z,
+    );
+    root.rotation.y = vehicle.yaw;
+
+    // Body lean: positive steerInput in valkyrie = turn left, so roll
+    // toward the right (negative Z rotation when looking down +X) feels
+    // correct as the chassis rolls outward in a turn.
+    const speedFrac = Math.min(1, Math.abs(vehicle.speed) / CAR.maxSpeed);
+    const steer = Math.abs(vehicle.steerInput) > STEER_THRESHOLD ? vehicle.steerInput : 0;
+    const targetRoll = -steer * ROLL_AMPLITUDE * speedFrac;
+    _roll += (targetRoll - _roll) * Math.min(1, dt * ROLL_LERP_RATE);
+
+    // Pitch: nose-down on accel, nose-up on brake. Estimate accel from
+    // d(speed)/dt without depending on Vehicle internals.
+    const accelEst = (vehicle.speed - _lastSpeed) / Math.max(1e-3, dt);
+    _lastSpeed = vehicle.speed;
+    const targetPitch = -Math.max(-1, Math.min(1, accelEst / CAR.accel)) * PITCH_AMPLITUDE;
+    _pitch += (targetPitch - _pitch) * Math.min(1, dt * PITCH_LERP_RATE);
+
+    body.rotation.z = _roll;
+    body.rotation.x = _pitch;
+
+    // Wheel spin (only fires if we matched named wheels above).
+    if (wheels.length > 0) {
+      const rollSpeed = vehicle.speed / wheelRadius;
+      for (const w of wheels) {
+        w.node.rotation.x -= rollSpeed * dt;
+        // Steering wheels turn slightly with input.
+        if (w.isFront) w.node.rotation.y = vehicle.steerInput * 0.4;
+      }
+    }
+  }
+
+  function destroy() {
+    scene.remove(root);
+    // Materials/geometry are shared via _cachedScene — do NOT dispose.
+  }
+
+  /**
+   * Stub for parity with the sprite API — the mirror system used to grab
+   * the active sprite texture. With a 3D mesh there's no single texture
+   * to return, so this returns null and the mirror falls back to whatever
+   * default it has.
+   */
+  function getActiveTexture() { return null; }
+
+  return { update, destroy, getActiveTexture, root };
+}

--- a/lib/game/state.js
+++ b/lib/game/state.js
@@ -59,6 +59,7 @@ export function createGameState(deps) {
   } = deps;
   // Reused buffers for hot gameplay actions.
   const _muzzleWorld = new THREE.Vector3();
+  const _rightVec    = new THREE.Vector3();
   const _ramHits = [];
   // deps is kept in scope so splatMoot can call deps.onSplatMoot if present.
 
@@ -314,8 +315,14 @@ export function createGameState(deps) {
       setFace('angry', MIRROR.angryMs);
       return false;
     }
-    // Beam origin = front of the vehicle in world space; pistol projects it.
-    _muzzleWorld.copy(vehicle.position).addScaledVector(vehicle.forward, CAR.spriteScale * 0.5);
+    // Beam origin = driver-side window in world space; pistol projects it.
+    // _rightVec = vehicle.forward rotated 90° CW in XZ → world right.
+    // Driver-side (US convention) is left of forward, so subtract.
+    _rightVec.set(-vehicle.forward.z, 0, vehicle.forward.x);
+    _muzzleWorld.copy(vehicle.position)
+      .addScaledVector(vehicle.forward, 1.8)   // ahead of cab
+      .addScaledVector(_rightVec, -0.7);       // driver-side
+    _muzzleWorld.y += 1.6;                     // window height
     if (!pistol.tryFire(_muzzleWorld, camera, aim.point)) return false;
     game.charge -= GAME.firingCostAmmo;
     impactSystem.spawnImpact(aim.point, 0xffaa55, 1.4);

--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ import { buildHighwayMesh } from './lib/world/highway/highwayMesh.js';
 import { buildParkAssets } from './lib/world/park/parkGenerator.js';
 import { createChunkManager } from './lib/world/chunks/chunkManager.js';
 import { loadAllVehicleTextures } from './lib/assets/vehicleTextures.js';
-import { createPlayerSprite } from './lib/car/playerSprite.js';
+import { createPlayerMesh } from './lib/car/playerMesh.js';
 import { createImpactSystem } from './lib/game/impacts.js';
 import { createGameState } from './lib/game/state.js';
 import { generateCity, generateCityLayout, hydrateCityLayout, serializeCityLayout } from './lib/world/city/generator.js';
@@ -1156,7 +1156,7 @@ async function buildCity(seed) {
   vehicle.setPositionYaw(currentPlayerSpawn.x, currentPlayerSpawn.z, 0);
 
   // Re-create player sprite for the new city.
-  playerSprite = createPlayerSprite(scene);
+  playerSprite = await createPlayerMesh(scene);
 
   // Re-create target marker.
   targetMarker = createTargetMarker(scene, { getTerrainY: terrainSystem.getTerrainY });
@@ -1513,7 +1513,7 @@ function tick(now) {
       } else {
         vehicle.update(dt, game);
         if (!noclip) resolveBuildingCollisions(vehicle, buildingGrid ?? buildingAABBs);
-        if (playerSprite) playerSprite.update(vehicle);
+        if (playerSprite) playerSprite.update(vehicle, dt);
         vehicle.applyChaseCamera(camera);
       }
 
@@ -1615,7 +1615,7 @@ function tick(now) {
 
   // Update player sprite position / frame (must happen before applyChaseCamera
   // so the sprite position is set before the camera moves to look at it).
-  if (playerSprite) playerSprite.update(vehicle);
+  if (playerSprite) playerSprite.update(vehicle, dt);
 
   // Third-person chase camera (after sprite update so lookAt is stable).
   vehicle.applyChaseCamera(camera);


### PR DESCRIPTION
## Summary
- Player vehicle is now a 3D GLB mesh instead of a directional sprite
- Body roll on steer + slight pitch on accel
- Laser beam emits from driver-side window, not truck centre
- Closes the player-side half of #2; #3 vehicle physics overhaul still untouched

## Changes
**Added**
- ``data/vehicles/player-truck.glb`` — the model (35 MB, PBR materials)
- ``lib/car/playerMesh.js`` — GLB loader + per-frame pose from existing Vehicle state (``position``, ``yaw``, ``speed``, ``steerInput``). Body lean and pitch tuning ported from crazy-cabbie. Optional wheel-spin if the model has Kenney-style named wheel nodes.

**Modified (+14/-6 lines)**
- ``index.html`` — ``three/addons/`` importmap entry so ``GLTFLoader`` resolves
- ``main.js`` — swap ``createPlayerSprite`` → ``await createPlayerMesh``; pass ``dt`` to ``update()``
- ``lib/game/state.js`` — muzzle world-position offset to driver-side window (forward 1.8m, left 0.7m, up 1.6m)

## Compatibility with #2 / #3
- Vehicle physics (``lib/car/vehicle.js``) and collision (``lib/car/collision.js``) untouched — #3 owns those
- NPC vehicles (``lib/entities/npcVehicle.js``) untouched — still sprite-based; #2 will close that gap
- Materials are stock GLB (``MeshStandardMaterial`` + PBR maps), so they pick up develop's existing scene lights without further setup

## Tunables
Constants at top of ``lib/car/playerMesh.js``:
- ``TRUCK_SCALE`` — currently 8
- ``MODEL_FACING_OFFSET`` — 0 (model is authored facing -Z, matching ``vehicle.forward``)
- ``FORWARD_OFFSET_Y`` — 0 (model origin is at base)
- ``ROLL_AMPLITUDE`` / ``PITCH_AMPLITUDE`` — body-lean intensity

## Test plan
- [ ] Load http://localhost:8090 — overlay shows kit/truck preload, then world renders
- [ ] Truck visible from chase camera, faces direction of travel
- [ ] Body rolls outward on hard turns, pitches forward on heavy accel
- [ ] Laser beam visually emits from the driver-side window, not the bed
- [ ] Restart (R) — no console errors, no missing/duplicated truck